### PR TITLE
Issue #54: 自身の会員情報を削除するリクエストが成功しても端末に会員情報が残ってしまう

### DIFF
--- a/NCMB/NCMBUser.swift
+++ b/NCMB/NCMBUser.swift
@@ -520,6 +520,7 @@ public class NCMBUser : NCMBBase {
                 case .success(_):
                     if self.isCurrentUser() {
                         NCMBUser.deleteFile()
+                        NCMBUser._currentUser = nil
                     }
                     self.removeAllFields()
                     self.removeAllModifiedFieldKeys()


### PR DESCRIPTION
## 概要(Summary)

- Fixed #54 

## 動作確認手順(Step for Confirmation)

Run the unit test.
