### PR TITLE
Current installation contain createDate key

### DIFF
--- a/NCMB/NCMBInstallation.swift
+++ b/NCMB/NCMBInstallation.swift
@@ -239,7 +239,8 @@ public class NCMBInstallation : NCMBBase {
         let data : Data? = manager.loadFromFile(target: .currentInstallation)
         if let data : Data = data {
             do {
-                let fields : [String : Any] = try NCMBJsonConverter.convertToKeyValue(data)
+                var fields : [String : Any] = try NCMBJsonConverter.convertToKeyValue(data)
+                fields["createDate"] = nil
                 return NCMBInstallation(className: NCMBInstallation.CLASSNAME, fields: fields)
             } catch let error {
                 NSLog("NCMB: Failed to acquire local file with current installation : \(error)")


### PR DESCRIPTION

## 概要(Summary)
The ```createDate``` exist in currentInstallation object, so can not update or re-install.
An idea is remove this key from currentInstallation.

- Fixed #xx

## 動作確認手順(Step for Confirmation)

Run the unit test.
