### PR TITLE
Add Package.swift

### DIFF
--- a/NCMB/NCMBPush.swift
+++ b/NCMB/NCMBPush.swift
@@ -433,15 +433,15 @@ public class NCMBPush : NCMBBase {
     }
 
     public static func handleRichPush(userInfo: [String : AnyObject]?, completion: @escaping () -> Void = {}) {
-        if let urlStr = userInfo?["com.nifcloud.mbaas.RichUrl"] as? String {
-            let richPushView = NCMBRichPushView()
-            richPushView.richUrl = urlStr
-            richPushView.closeCallback = completion
-            DispatchQueue.main.async {
-                #if os(iOS)
+        #if os(iOS)
+            if let urlStr = userInfo?["com.nifcloud.mbaas.RichUrl"] as? String {
+                let richPushView = NCMBRichPushView()
+                richPushView.richUrl = urlStr
+                richPushView.closeCallback = completion
+                DispatchQueue.main.async {
                     UIApplication.shared.keyWindow?.rootViewController?.present(richPushView, animated: true, completion: nil)
-                #endif
+                }
             }
-        }
+        #endif
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.2
+
+import PackageDescription
+
+let package = Package(
+    name: "NCMB",
+    platforms: [
+        .iOS(.v10), .macOS(.v10_12)
+    ],
+    products: [
+        .library(name: "NCMB", targets: ["NCMB"]),
+    ],
+    targets: [
+        .target(
+            name: "NCMB",
+            dependencies: [],
+            path: "NCMB"
+        ),
+        .testTarget(
+            name: "NCMBTests",
+            dependencies: ["NCMB"],
+            path: "NCMBTests"
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
## 概要(Summary)

- SwiftPackageManagerによるパッケージ管理を有効にするために、 `Package.swift` を配置します。
- SwiftPackageManagerによるパッケージ管理が有効である場合、Xcodeのプロジェクト設定のSwift Packagesタブからライブラリが使用できるようになるほか、macOS上における単発のスクリプトなどからもライブラリを参照できるようになるため有用であると考えます。
- また作業の途中でmacOS環境向けのビルドに失敗してしまうことに気づきました。一部の `#if` による分岐が正しくなかったことによるものです。そのためもとの挙動を変えないようにしつつ `NCMBPush.swift ` を若干変更しています。

## 動作確認手順(Step for Confirmation)

- プロジェクトのルートディレクトリで `swift build` `swift test` 等のコマンドを実行し、失敗しないか
- プロジェクトのルートディレクトリをXcodeで開き、Xcode上からのビルド及びテストが成功するか（要Xcode11以上）
- 何らかのiOSアプリケーションのプロジェクトからXcodeを用いてパッケージの依存を解決し、アプリケーションをビルドして実行し正しく動作するか
