### PR TITLE
Fix build error on linux environment

### DIFF
--- a/NCMB/NCMBPush.swift
+++ b/NCMB/NCMBPush.swift
@@ -433,15 +433,15 @@ public class NCMBPush : NCMBBase {
     }
 
     public static func handleRichPush(userInfo: [String : AnyObject]?, completion: @escaping () -> Void = {}) {
-        if let urlStr = userInfo?["com.nifcloud.mbaas.RichUrl"] as? String {
-            let richPushView = NCMBRichPushView()
-            richPushView.richUrl = urlStr
-            richPushView.closeCallback = completion
-            DispatchQueue.main.async {
-                #if os(iOS)
+        #if os(iOS)
+            if let urlStr = userInfo?["com.nifcloud.mbaas.RichUrl"] as? String {
+                let richPushView = NCMBRichPushView()
+                richPushView.richUrl = urlStr
+                richPushView.closeCallback = completion
+                DispatchQueue.main.async {
                     UIApplication.shared.keyWindow?.rootViewController?.present(richPushView, animated: true, completion: nil)
-                #endif
+                }
             }
-        }
+        #endif
     }
 }

--- a/NCMB/NCMBUser.swift
+++ b/NCMB/NCMBUser.swift
@@ -599,9 +599,10 @@ public class NCMBUser : NCMBBase {
     public func signUpWithFacebookToken(facebookParameters:
         NCMBFacebookParameters, callback: @escaping NCMBHandler<Void> )
         -> Void {
-            let facebookInfo:NSMutableDictionary = NSMutableDictionary()
-            facebookInfo.setValue(facebookParameters.toObject(), forKey: facebookParameters.type.rawValue)
-            signUpWithToken(snsInfo: facebookInfo, callback: callback)
+        let facebookInfo: [String: Any] = [
+            facebookParameters.type.rawValue: facebookParameters.toObject(),
+        ]
+        signUpWithToken(snsInfo: facebookInfo, callback: callback)
     }
     
     /// appleのauthDataをもとにニフクラ mobile backendへの会員登録(ログイン)を行う
@@ -609,8 +610,9 @@ public class NCMBUser : NCMBBase {
     /// - Parameter appleParameters: NCMBAppleParameters
     /// - Parameter callback: レスポンス取得後に実行されるコールバックです。
     public func signUpWithAppleToken(appleParameters: NCMBAppleParameters, callback: @escaping NCMBHandler<Void> ) -> Void {
-        let appleInfo:NSMutableDictionary = NSMutableDictionary()
-        appleInfo.setValue(appleParameters.toObject(), forKey: appleParameters.type.rawValue)
+        let appleInfo: [String: Any] = [
+            appleParameters.type.rawValue: appleParameters.toObject(),
+        ]
         signUpWithToken(snsInfo: appleInfo, callback: callback)
     }
     
@@ -618,9 +620,9 @@ public class NCMBUser : NCMBBase {
     ///
     /// - Parameter snsInfo: snsの認証に必要なauthData
     /// - Parameter callback: レスポンス取得後に実行されるコールバックです。
-    public func signUpWithToken(snsInfo:NSMutableDictionary, callback: @escaping NCMBHandler<Void> ) -> Void {
+    public func signUpWithToken(snsInfo: [String: Any], callback: @escaping NCMBHandler<Void> ) -> Void {
         let localAuthData = self.authData
-        self.authData = snsInfo as? [String:Any]
+        self.authData = snsInfo
         if localAuthData != nil {
             let localAuthDataDictionary = NSMutableDictionary(dictionary: localAuthData!)
             localAuthDataDictionary.addEntries(from: self.authData!)
@@ -643,9 +645,10 @@ public class NCMBUser : NCMBBase {
     ///
     /// - Parameter FacebookParameters: NCMBFacebookParameters
     /// - Parameter callback: レスポンス取得後に実行されるコールバックです。
-    public func linkWithFacebookToken(FacebookParameters: NCMBFacebookParameters, callback: @escaping NCMBHandler<Void> ) -> Void {
-        let facebookInfo:NSMutableDictionary = NSMutableDictionary()
-        facebookInfo.setValue(FacebookParameters.toObject(), forKey: FacebookParameters.type.rawValue)
+    public func linkWithFacebookToken(facebookParameters: NCMBFacebookParameters, callback: @escaping NCMBHandler<Void> ) -> Void {
+        let facebookInfo: [String: Any] = [
+            facebookParameters.type.rawValue: facebookParameters.toObject(),
+        ]
         linkWithToken(snsInfo: facebookInfo, callback: callback)
     }
     
@@ -654,8 +657,9 @@ public class NCMBUser : NCMBBase {
     /// - Parameter appleParameters: NCMBAppleParameters
     /// - Parameter callback: レスポンス取得後に実行されるコールバックです。
     public func linkWithAppleToken(appleParameters: NCMBAppleParameters, callback: @escaping NCMBHandler<Void> ) -> Void {
-        let appleInfo:NSMutableDictionary = NSMutableDictionary()
-        appleInfo.setValue(appleParameters.toObject(), forKey: appleParameters.type.rawValue)
+        let appleInfo: [String: Any] = [
+            appleParameters.type.rawValue: appleParameters.toObject(),
+        ]
         linkWithToken(snsInfo: appleInfo, callback: callback)
     }
     
@@ -663,11 +667,11 @@ public class NCMBUser : NCMBBase {
     ///
     /// - Parameter snsInfo: NSMutableDictionary
     /// - Parameter callback: レスポンス取得後に実行されるコールバックです。
-    public func linkWithToken(snsInfo:NSMutableDictionary, callback: @escaping NCMBHandler<Void>) -> Void {
+    public func linkWithToken(snsInfo: [String: Any], callback: @escaping NCMBHandler<Void>) -> Void {
         var localAuthData: [String : Any]? = nil
         localAuthData = self.authData
         
-        self.authData = snsInfo as? [String : Any]
+        self.authData = snsInfo
         self.saveInBackground { result in
             switch result {
             case .success :
@@ -716,9 +720,9 @@ public class NCMBUser : NCMBBase {
         if self.authData != nil {
             if self.isLinkedWith(type: type) {
                 let localAuthData = self.authData
-                let localAuthDataDictionary = NSMutableDictionary(dictionary: self.authData!)
-                localAuthDataDictionary.setObject(NSNull(), forKey: type as NSCopying)
-                self.authData = localAuthDataDictionary as? [String:Any]
+                self.authData = [
+                    type: NSNull(),
+                ]
                 self.saveInBackground { result in
                     switch result {
                     case .success :

--- a/NCMB/network/NCMBRequest.swift
+++ b/NCMB/network/NCMBRequest.swift
@@ -15,6 +15,9 @@
  */
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 struct NCMBRequest {
 

--- a/NCMB/network/NCMBRequestExecutor.swift
+++ b/NCMB/network/NCMBRequestExecutor.swift
@@ -15,6 +15,9 @@
  */
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 struct NCMBRequestExecutor : NCMBRequestExecutorProtocol {
 

--- a/NCMB/network/NCMBResponse.swift
+++ b/NCMB/network/NCMBResponse.swift
@@ -15,6 +15,9 @@
  */
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// リクエストからの返却内容を保持する構造体です。
 public struct NCMBResponse {

--- a/NCMB/network/NCMBSession.swift
+++ b/NCMB/network/NCMBSession.swift
@@ -15,6 +15,9 @@
  */
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 struct NCMBSession : NCMBSessionProtocol {
 

--- a/NCMB/network/NCMBSessionProtocol.swift
+++ b/NCMB/network/NCMBSessionProtocol.swift
@@ -15,6 +15,9 @@
  */
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 protocol NCMBSessionProtocol {
 

--- a/NCMB/network/NCMBSignatureCalculator.swift
+++ b/NCMB/network/NCMBSignatureCalculator.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if os(OSX) || os(iOS)
+#if canImport(CommonCrypto)
     import CommonCrypto
 #else
     import CryptoSwift
@@ -107,7 +107,7 @@ class NCMBSignatureCalculator {
         return array.joined(separator: "&")
     }
 
-    #if os(OSX) || os(iOS)
+    #if canImport(CommonCrypto)
 
     class func calculateSignature(plaintext: String, clientKey: String) throws -> String {
         guard let bytes = plaintext.cString(using: .utf8) else {
@@ -127,7 +127,7 @@ class NCMBSignatureCalculator {
         return hmac.base64EncodedString()
     }
 
-    #elseif os(Linux)
+    #else
 
     class func calculateSignature(plaintext: String, clientKey: String) throws -> String {
         let bytes : [UInt8] = Array(plaintext.utf8)

--- a/NCMBTests/NCMBFileTests.swift
+++ b/NCMBTests/NCMBFileTests.swift
@@ -17,6 +17,9 @@
 
 import XCTest
 @testable import NCMB
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// NCMBFile のテストクラスです。
 final class NCMBFileTests: NCMBTestCase {

--- a/NCMBTests/NCMBUserTests.swift
+++ b/NCMBTests/NCMBUserTests.swift
@@ -2873,15 +2873,16 @@ final class NCMBUserTests: NCMBTestCase {
         let facebookParameters: NCMBFacebookParameters = NCMBFacebookParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw",
             expirationDate:
             Date(timeIntervalSince1970: 507904496.789))
-        let facebookInfo:NSMutableDictionary = NSMutableDictionary()
-        facebookInfo.setValue(facebookParameters.toObject(), forKey: facebookParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(facebookInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let facebookInfo: [String: Any] = [
+            facebookParameters.type.rawValue: facebookParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": facebookInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -2893,8 +2894,7 @@ final class NCMBUserTests: NCMBTestCase {
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
             XCTAssertNotNil(NCMBUser.currentUser!.authData)
-            let facebook:[String:Any] = (facebookInfo as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebook))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebookInfo))
             expectation?.fulfill()
         })
 
@@ -2966,28 +2966,28 @@ final class NCMBUserTests: NCMBTestCase {
         //Linkwith facebook
         let facebookParameters: NCMBFacebookParameters = NCMBFacebookParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw",expirationDate:
             Date(timeIntervalSince1970: 507904496.789))
-        let facebookInfo:NSMutableDictionary = NSMutableDictionary()
-        facebookInfo.setValue(facebookParameters.toObject(), forKey: facebookParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(facebookInfo, forKey: "authData")
-        let contentsFacebook : [String:Any] = (data as? [String:Any])!
+        let facebookInfo: [String: Any] = [
+            facebookParameters.type.rawValue: facebookParameters.toObject(),
+        ]
+        let contentsFacebook: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": facebookInfo,
+        ]
         let responseFacebook : NCMBResponse = MockResponseBuilder.createResponse(contents: contentsFacebook, statusCode : 201)
         let executorFacebook = MockRequestExecutor(result: .success(responseFacebook))
         NCMBRequestExecutorFactory.setInstance(executor: executorFacebook)
         let expectation : XCTestExpectation? = self.expectation(description: "test_logIn_userName_and_link_with_facebook_success")
         let currentUser : NCMBUser = NCMBUser.currentUser!
-        currentUser.linkWithFacebookToken(FacebookParameters: facebookParameters, callback: { (result: NCMBResult<Void>) in
+        currentUser.linkWithFacebookToken(facebookParameters: facebookParameters, callback: { (result: NCMBResult<Void>) in
             XCTAssertTrue(NCMBTestUtil.checkResultIsSuccess(result: result))
             XCTAssertEqual(NCMBUser.currentUser!.objectId, "epaKcaYZqsREdSMY")
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
             XCTAssertNotNil(NCMBUser.currentUser!.authData)
-            let facebook:[String:Any] = (facebookInfo as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebook))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebookInfo))
             XCTAssertTrue(currentUser.isLinkedWith(type: "facebook"))
             expectation?.fulfill()
         })
@@ -2998,15 +2998,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_logIn_userName_and_link_with_facebook_failure() {
         // Response data for login
         let googleParameters: NCMBGoogleParameters = NCMBGoogleParameters(id: "googleId", accessToken: "google_access_token")
-        let googleInfo:NSMutableDictionary = NSMutableDictionary()
-        googleInfo.setValue(googleParameters.toObject(), forKey: googleParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(googleInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let googleInfo: [String: Any] = [
+            googleParameters.type.rawValue: googleParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": googleInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3022,13 +3023,12 @@ final class NCMBUserTests: NCMBTestCase {
         NCMBRequestExecutorFactory.setInstance(executor: MockRequestExecutor(result: .failure(error)))
         let expectation : XCTestExpectation? = self.expectation(description: "test_logIn_userName_and_link_with_facebook_failure")
         let currentUser : NCMBUser = NCMBUser.currentUser!
-        currentUser.linkWithFacebookToken(FacebookParameters: facebookParameters, callback: { (result: NCMBResult<Void>) in
+        currentUser.linkWithFacebookToken(facebookParameters: facebookParameters, callback: { (result: NCMBResult<Void>) in
             XCTAssertTrue(NCMBTestUtil.checkResultIsFailure(result: result))
             XCTAssertEqual(NCMBUser.currentUser!.objectId, "epaKcaYZqsREdSMY")
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
-            let google:[String:Any] = (googleInfo as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: google))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: googleInfo))
             //Confirm facebook key will be not exist in currentUser.authData
             XCTAssertNil(NCMBUser.currentUser!.authData!["facebook"])
             XCTAssertEqual(NCMBTestUtil.getError(result: result)! as NSError, error)
@@ -3042,15 +3042,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_logIn_userName_and_link_with_facebook_failure_E409001() {
         // Response data for login
         let googleParameters: NCMBGoogleParameters = NCMBGoogleParameters(id: "googleId", accessToken: "google_access_token")
-        let googleInfo:NSMutableDictionary = NSMutableDictionary()
-        googleInfo.setValue(googleParameters.toObject(), forKey: googleParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(googleInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let googleInfo: [String: Any] = [
+            googleParameters.type.rawValue: googleParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": googleInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3064,14 +3065,13 @@ final class NCMBUserTests: NCMBTestCase {
         NCMBRequestExecutorFactory.setInstance(executor: MockRequestExecutor(result: .failure(NCMBApiError.init(body: ["code" : "E409001", "error" : "authData is duplication."]))))
         let expectation : XCTestExpectation? = self.expectation(description: "test_logIn_userName_and_link_with_facebook_failure")
         let currentUser : NCMBUser = NCMBUser.currentUser!
-        currentUser.linkWithFacebookToken(FacebookParameters: facebookParameters, callback: { (result: NCMBResult<Void>) in
+        currentUser.linkWithFacebookToken(facebookParameters: facebookParameters, callback: { (result: NCMBResult<Void>) in
             XCTAssertTrue(NCMBTestUtil.checkResultIsFailure(result: result))
             let error = NCMBTestUtil.getError(result: result)! as! NCMBApiError
             XCTAssertEqual(NCMBUser.currentUser!.objectId, "epaKcaYZqsREdSMY")
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
-            let google:[String:Any] = (googleInfo as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: google))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: googleInfo))
             //Confirm facebook key will be not exist in currentUser.authData
             XCTAssertNil(NCMBUser.currentUser!.authData!["facebook"])
             XCTAssertEqual(error.errorCode, NCMBApiErrorCode(code: "E409001"))
@@ -3085,15 +3085,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_is_link_with_facebook_id() {
         // Response data for login
         let facebookParameters: NCMBFacebookParameters = NCMBFacebookParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw", expirationDate: Date(timeIntervalSince1970: 507904496.789))
-        let facebookInfo:NSMutableDictionary = NSMutableDictionary()
-        facebookInfo.setValue(facebookParameters.toObject(), forKey: facebookParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(facebookInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let facebookInfo: [String: Any] = [
+            facebookParameters.type.rawValue: facebookParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": facebookInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3104,8 +3105,7 @@ final class NCMBUserTests: NCMBTestCase {
         XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
         let currentUser : NCMBUser = NCMBUser.currentUser!
         XCTAssertNotNil(NCMBUser.currentUser!.authData)
-        let facebook:[String:Any] = (facebookInfo as? [String:Any])!
-        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebook))
+        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebookInfo))
         // Check islinkwith facebook id
         XCTAssertTrue(currentUser.isLinkedWith(type: "facebook"))
     }
@@ -3113,15 +3113,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_logIn_userName_and_unlink_with_facebook_success() {
         // Response data for login
         let facebookParameters: NCMBFacebookParameters = NCMBFacebookParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw", expirationDate: Date(timeIntervalSince1970: 507904496.789))
-        let facebookInfo:NSMutableDictionary = NSMutableDictionary()
-        facebookInfo.setValue(facebookParameters.toObject(), forKey: facebookParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(facebookInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let facebookInfo: [String: Any] = [
+            facebookParameters.type.rawValue: facebookParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": facebookInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3132,30 +3133,28 @@ final class NCMBUserTests: NCMBTestCase {
         XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
         let currentUser : NCMBUser = NCMBUser.currentUser!
         XCTAssertNotNil(NCMBUser.currentUser!.authData)
-        let facebook:[String:Any] = (facebookInfo as? [String:Any])!
-        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebook))
+        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebookInfo))
         // Unlinkwith facebook
-        let facebookInfoUnlink:NSMutableDictionary = NSMutableDictionary()
-        facebookInfoUnlink.setValue(NSNull(), forKey: facebookParameters.type.rawValue)
-        let dataUnlink : NSMutableDictionary = NSMutableDictionary()
-        dataUnlink.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        dataUnlink.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        dataUnlink.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        dataUnlink.setValue("Yamada Tarou", forKey: "userName")
-        dataUnlink.setValue(facebookInfoUnlink, forKey: "authData")
-        let contentsUnlink : [String:Any] = (dataUnlink as? [String:Any])!
+        let facebookInfoUnlink: [String: Any] = [
+            facebookParameters.type.rawValue: NSNull(),
+        ]
+        let contentsUnlink: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": facebookInfoUnlink,
+        ]
         let responseUnlink : NCMBResponse = MockResponseBuilder.createResponse(contents: contentsUnlink, statusCode : 201)
         let executorUnlink = MockRequestExecutor(result: .success(responseUnlink))
         NCMBRequestExecutorFactory.setInstance(executor: executorUnlink)
         let expectation : XCTestExpectation? = self.expectation(description: "test_logIn_userName_and_unlink_with_facebook_success")
-        facebookInfoUnlink.removeObject(forKey: facebookParameters.type.rawValue)
         currentUser.unlink(type: "facebook", callback: { (result: NCMBResult<Void>) in
             XCTAssertTrue(NCMBTestUtil.checkResultIsSuccess(result: result))
             XCTAssertEqual(NCMBUser.currentUser!.objectId, "epaKcaYZqsREdSMY")
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
-            let facebookUnlink:[String:Any] = (facebookInfoUnlink as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebookUnlink))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: [:]))
             XCTAssertFalse(currentUser.isLinkedWith(type: "facebook"))
             expectation?.fulfill()
         })
@@ -3166,15 +3165,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_logIn_userName_and_unlink_with_facebook_failure() {
         // Response data for login
         let facebookParameters: NCMBFacebookParameters = NCMBFacebookParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw", expirationDate: Date(timeIntervalSince1970: 507904496.789))
-        let facebookInfo:NSMutableDictionary = NSMutableDictionary()
-        facebookInfo.setValue(facebookParameters.toObject(), forKey: facebookParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(facebookInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let facebookInfo: [String: Any] = [
+            facebookParameters.type.rawValue: facebookParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": facebookInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3185,8 +3185,7 @@ final class NCMBUserTests: NCMBTestCase {
         XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
         let currentUser : NCMBUser = NCMBUser.currentUser!
         XCTAssertNotNil(NCMBUser.currentUser!.authData)
-        let facebook:[String:Any] = (facebookInfo as? [String:Any])!
-        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebook))
+        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebookInfo))
         // Unlinkwith facebook
         let error = NSError(domain: "NCMBErrorDomain", code: -1, userInfo: nil)
         NCMBRequestExecutorFactory.setInstance(executor: MockRequestExecutor(result: .failure(error)))
@@ -3197,7 +3196,7 @@ final class NCMBUserTests: NCMBTestCase {
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
             XCTAssertNotNil(NCMBUser.currentUser!.authData)
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebook))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: facebookInfo))
             XCTAssertEqual(NCMBTestUtil.getError(result: result)! as NSError, error)
             XCTAssertTrue(currentUser.isLinkedWith(type: "facebook"))
             expectation?.fulfill()
@@ -3208,12 +3207,12 @@ final class NCMBUserTests: NCMBTestCase {
 
     func test_is_unlink_with_facebook_id() {
         // Response data for login
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3229,15 +3228,16 @@ final class NCMBUserTests: NCMBTestCase {
 
     func test_signWithAppleId_success() {
         let appleParameters: NCMBAppleParameters = NCMBAppleParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw")
-        let appleInfo:NSMutableDictionary = NSMutableDictionary()
-        appleInfo.setValue(appleParameters.toObject(), forKey: appleParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(appleInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let appleInfo: [String: Any] = [
+            appleParameters.type.rawValue: appleParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": appleInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3249,8 +3249,7 @@ final class NCMBUserTests: NCMBTestCase {
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
             XCTAssertNotNil(NCMBUser.currentUser!.authData)
-            let apple:[String:Any] = (appleInfo as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: apple))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: appleInfo))
             expectation?.fulfill()
         })
 
@@ -3285,15 +3284,16 @@ final class NCMBUserTests: NCMBTestCase {
         XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
         //Linkwith apple id
         let appleParameters: NCMBAppleParameters = NCMBAppleParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw")
-        let appleInfo:NSMutableDictionary = NSMutableDictionary()
-        appleInfo.setValue(appleParameters.toObject(), forKey: appleParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(appleInfo, forKey: "authData")
-        let contentsApple : [String:Any] = (data as? [String:Any])!
+        let appleInfo: [String: Any] = [
+            appleParameters.type.rawValue: appleParameters.toObject(),
+        ]
+        let contentsApple: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": appleInfo,
+        ]
         let responseApple : NCMBResponse = MockResponseBuilder.createResponse(contents: contentsApple, statusCode : 201)
         let executorApple = MockRequestExecutor(result: .success(responseApple))
         NCMBRequestExecutorFactory.setInstance(executor: executorApple)
@@ -3305,8 +3305,7 @@ final class NCMBUserTests: NCMBTestCase {
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
             XCTAssertNotNil(NCMBUser.currentUser!.authData)
-            let apple:[String:Any] = (appleInfo as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: apple))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: appleInfo))
             XCTAssertTrue(currentUser.isLinkedWith(type: "apple"))
             expectation?.fulfill()
         })
@@ -3317,15 +3316,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_logIn_userName_and_link_with_apple_id_failure() {
         // Response data for login
         let googleParameters: NCMBGoogleParameters = NCMBGoogleParameters(id: "googleId", accessToken: "google_access_token")
-        let googleInfo:NSMutableDictionary = NSMutableDictionary()
-        googleInfo.setValue(googleParameters.toObject(), forKey: googleParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(googleInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let googleInfo: [String: Any] = [
+            googleParameters.type.rawValue: googleParameters.toObject(), 
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": googleInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3345,8 +3345,7 @@ final class NCMBUserTests: NCMBTestCase {
             XCTAssertEqual(NCMBUser.currentUser!.objectId, "epaKcaYZqsREdSMY")
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
-            let google:[String:Any] = (googleInfo as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: google))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: googleInfo))
             //Confirm apple key will be not exist in currentUser.authData
             XCTAssertNil(NCMBUser.currentUser!.authData!["apple"])
             XCTAssertEqual(NCMBTestUtil.getError(result: result)! as NSError, error)
@@ -3360,15 +3359,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_logIn_userName_and_unlink_with_apple_id_success() {
         // Response data for login
         let appleParameters: NCMBAppleParameters = NCMBAppleParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw")
-        let appleInfo:NSMutableDictionary = NSMutableDictionary()
-        appleInfo.setValue(appleParameters.toObject(), forKey: appleParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(appleInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let appleInfo: [String: Any] = [
+            appleParameters.type.rawValue: appleParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": appleInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3379,30 +3379,28 @@ final class NCMBUserTests: NCMBTestCase {
         XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
         let currentUser : NCMBUser = NCMBUser.currentUser!
         XCTAssertNotNil(NCMBUser.currentUser!.authData)
-        let apple:[String:Any] = (appleInfo as? [String:Any])!
-        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: apple))
+        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: appleInfo))
         // Unlinkwith apple id
-        let appleInfoUnlink:NSMutableDictionary = NSMutableDictionary()
-        appleInfoUnlink.setValue(NSNull(), forKey: appleParameters.type.rawValue)
-        let dataUnlink : NSMutableDictionary = NSMutableDictionary()
-        dataUnlink.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        dataUnlink.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        dataUnlink.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        dataUnlink.setValue("Yamada Tarou", forKey: "userName")
-        dataUnlink.setValue(appleInfoUnlink, forKey: "authData")
-        let contentsUnlink : [String:Any] = (dataUnlink as? [String:Any])!
+        let appleInfoUnlink: [String: Any] = [
+            appleParameters.type.rawValue: NSNull(),
+        ]
+        let contentsUnlink : [String:Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": appleInfoUnlink,
+        ]
         let responseUnlink : NCMBResponse = MockResponseBuilder.createResponse(contents: contentsUnlink, statusCode : 201)
         let executorUnlink = MockRequestExecutor(result: .success(responseUnlink))
         NCMBRequestExecutorFactory.setInstance(executor: executorUnlink)
         let expectation : XCTestExpectation? = self.expectation(description: "test_logIn_userName_and_unlink_with_apple_id_success")
-        appleInfoUnlink.removeObject(forKey: appleParameters.type.rawValue)
         currentUser.unlink(type: "apple", callback: { (result: NCMBResult<Void>) in
             XCTAssertTrue(NCMBTestUtil.checkResultIsSuccess(result: result))
             XCTAssertEqual(NCMBUser.currentUser!.objectId, "epaKcaYZqsREdSMY")
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
-            let appleUnlink:[String:Any] = (appleInfoUnlink as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: appleUnlink))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: [:]))
             XCTAssertFalse(currentUser.isLinkedWith(type: "apple"))
             expectation?.fulfill()
         })
@@ -3413,15 +3411,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_logIn_userName_and_unlink_with_apple_id_failure() {
         // Response data for login
         let appleParameters: NCMBAppleParameters = NCMBAppleParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw")
-        let appleInfo:NSMutableDictionary = NSMutableDictionary()
-        appleInfo.setValue(appleParameters.toObject(), forKey: appleParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(appleInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let appleInfo: [String: Any] = [
+            appleParameters.type.rawValue: appleParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": appleInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3432,8 +3431,7 @@ final class NCMBUserTests: NCMBTestCase {
         XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
         let currentUser : NCMBUser = NCMBUser.currentUser!
         XCTAssertNotNil(NCMBUser.currentUser!.authData)
-        let apple:[String:Any] = (appleInfo as? [String:Any])!
-        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: apple))
+        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: appleInfo))
         // Unlinkwith apple id
         let error = NSError(domain: "NCMBErrorDomain", code: -1, userInfo: nil)
         NCMBRequestExecutorFactory.setInstance(executor: MockRequestExecutor(result: .failure(error)))
@@ -3444,7 +3442,7 @@ final class NCMBUserTests: NCMBTestCase {
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
             XCTAssertNotNil(NCMBUser.currentUser!.authData)
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: apple))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: appleInfo))
             XCTAssertEqual(NCMBTestUtil.getError(result: result)! as NSError, error)
             XCTAssertTrue(currentUser.isLinkedWith(type: "apple"))
             expectation?.fulfill()
@@ -3456,15 +3454,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_is_link_with_apple_id() {
         // Response data for login
         let appleParameters: NCMBAppleParameters = NCMBAppleParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw")
-        let appleInfo:NSMutableDictionary = NSMutableDictionary()
-        appleInfo.setValue(appleParameters.toObject(), forKey: appleParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(appleInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let appleInfo: [String: Any] = [
+            appleParameters.type.rawValue: appleParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": appleInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3475,20 +3474,19 @@ final class NCMBUserTests: NCMBTestCase {
         XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
         let currentUser : NCMBUser = NCMBUser.currentUser!
         XCTAssertNotNil(NCMBUser.currentUser!.authData)
-        let apple:[String:Any] = (appleInfo as? [String:Any])!
-        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: apple))
+        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: appleInfo))
         // Check islinkwith apple id
         XCTAssertTrue(currentUser.isLinkedWith(type: "apple"))
     }
 
     func test_is_unlink_with_apple_id() {
         // Response data for login
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3505,15 +3503,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_logIn_userName_and_link_with_apple_id_when_already_other_token_success() {
         // Response data for login
         let googleParameters : NCMBGoogleParameters = NCMBGoogleParameters(id: "google_user_id", accessToken: "google_user_access_token")
-        let googleInfo:NSMutableDictionary = NSMutableDictionary()
-        googleInfo.setValue(googleParameters.toObject(), forKey: googleParameters.type.rawValue)
-        let loginData : NSMutableDictionary = NSMutableDictionary()
-        loginData.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        loginData.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        loginData.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        loginData.setValue("Yamada Tarou", forKey: "userName")
-        loginData.setValue(googleInfo, forKey: "authData")
-        let contents : [String : Any] = (loginData as? [String:Any])!
+        let googleInfo: [String: Any] = [
+            googleParameters.type.rawValue: googleParameters.toObject()
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": googleInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3523,20 +3522,20 @@ final class NCMBUserTests: NCMBTestCase {
         XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
         XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
         XCTAssertNotNil(NCMBUser.currentUser!.authData)
-        let google:[String:Any] = (googleInfo as? [String:Any])!
-        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: google))
+        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: googleInfo))
         //Linkwith apple id
         let appleParameters: NCMBAppleParameters = NCMBAppleParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw")
-        let snsInputInfo:NSMutableDictionary = NSMutableDictionary()
-        snsInputInfo.setValue(appleParameters.toObject(), forKey: appleParameters.type.rawValue)
-        snsInputInfo.setValue(googleParameters.toObject(), forKey: googleParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(snsInputInfo, forKey: "authData")
-        let contentsApple : [String:Any] = (data as? [String:Any])!
+        let snsInputInfo: [String: Any] = [
+            appleParameters.type.rawValue: appleParameters.toObject(),
+            googleParameters.type.rawValue: googleParameters.toObject(),
+        ]
+        let contentsApple: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": snsInputInfo,
+        ]
         let responseApple : NCMBResponse = MockResponseBuilder.createResponse(contents: contentsApple, statusCode : 201)
         let executorApple = MockRequestExecutor(result: .success(responseApple))
         NCMBRequestExecutorFactory.setInstance(executor: executorApple)
@@ -3548,8 +3547,7 @@ final class NCMBUserTests: NCMBTestCase {
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
             XCTAssertNotNil(NCMBUser.currentUser!.authData)
-            let expected: [String:Any] = (snsInputInfo as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: expected))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: snsInputInfo))
             expectation?.fulfill()
         })
 
@@ -3559,15 +3557,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_logIn_userName_and_link_with_apple_id_when_already_other_token_failure() {
         // Response data for login
         let googleParameters : NCMBGoogleParameters = NCMBGoogleParameters(id: "google_user_id", accessToken: "google_user_access_token")
-        let googleInfo:NSMutableDictionary = NSMutableDictionary()
-        googleInfo.setValue(googleParameters.toObject(), forKey: googleParameters.type.rawValue)
-        let loginData : NSMutableDictionary = NSMutableDictionary()
-        loginData.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        loginData.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        loginData.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        loginData.setValue("Yamada Tarou", forKey: "userName")
-        loginData.setValue(googleInfo, forKey: "authData")
-        let contents : [String : Any] = (loginData as? [String:Any])!
+        let googleInfo: [String: Any] = [
+            googleParameters.type.rawValue: googleParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": googleInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3577,8 +3576,7 @@ final class NCMBUserTests: NCMBTestCase {
         XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
         XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
         XCTAssertNotNil(NCMBUser.currentUser!.authData)
-        let google:[String:Any] = (googleInfo as? [String:Any])!
-        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: google))
+        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: googleInfo))
         //Linkwith apple id
         let appleParameters: NCMBAppleParameters = NCMBAppleParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw")
         NCMBRequestExecutorFactory.setInstance(executor: MockRequestExecutor(result: .failure(DummyErrors.dummyError)))
@@ -3590,8 +3588,7 @@ final class NCMBUserTests: NCMBTestCase {
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
             XCTAssertNotNil(NCMBUser.currentUser!.authData)
-            let google:[String:Any] = (googleInfo as? [String:Any])!
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: google))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: googleInfo))
             //Confirm apple key will be not exist in currentUser.authData
             XCTAssertNil(NCMBUser.currentUser!.authData!["apple"])
             expectation?.fulfill()
@@ -3602,12 +3599,12 @@ final class NCMBUserTests: NCMBTestCase {
 
     func test_unlink_with_apple_id_token_not_found() {
         // Response data for login
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3637,15 +3634,16 @@ final class NCMBUserTests: NCMBTestCase {
     func test_logIn_userName_and_unlink_with_other_token_failure() {
         // Response data for login
         let appleParameters: NCMBAppleParameters = NCMBAppleParameters(id: "000249.a6d59722849d4439aee4d1618ab0d109.1111", accessToken: "c1a51b66edfca470abad0d8fff1acd3d4.0.nsut.IA2zvk92-1bWebpVwxNsGw")
-        let appleInfo:NSMutableDictionary = NSMutableDictionary()
-        appleInfo.setValue(appleParameters.toObject(), forKey: appleParameters.type.rawValue)
-        let data : NSMutableDictionary = NSMutableDictionary()
-        data.setValue("2013-08-28T11:27:16.446Z", forKey: "createDate")
-        data.setValue("epaKcaYZqsREdSMY", forKey: "objectId")
-        data.setValue("iXDIelJRY3ULBdms281VTmc5O", forKey: "sessionToken")
-        data.setValue("Yamada Tarou", forKey: "userName")
-        data.setValue(appleInfo, forKey: "authData")
-        let contents : [String:Any] = (data as? [String:Any])!
+        let appleInfo: [String: Any] = [
+            appleParameters.type.rawValue: appleParameters.toObject(),
+        ]
+        let contents: [String: Any] = [
+            "createDate": "2013-08-28T11:27:16.446Z",
+            "objectId": "epaKcaYZqsREdSMY",
+            "sessionToken": "iXDIelJRY3ULBdms281VTmc5O",
+            "userName": "Yamada Tarou",
+            "authData": appleInfo,
+        ]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode : 201)
         let executor = MockRequestExecutor(result: .success(response))
         NCMBRequestExecutorFactory.setInstance(executor: executor)
@@ -3656,8 +3654,7 @@ final class NCMBUserTests: NCMBTestCase {
         XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
         let currentUser : NCMBUser = NCMBUser.currentUser!
         XCTAssertNotNil(NCMBUser.currentUser!.authData)
-        let apple:[String:Any] = (appleInfo as? [String:Any])!
-        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: apple))
+        XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: appleInfo))
         // Unlinkwith apple id
         NCMBRequestExecutorFactory.setInstance(executor: MockRequestExecutor(result: .failure(DummyErrors.dummyError)))
         let expectation : XCTestExpectation? = self.expectation(description: "test_logIn_userName_and_unlink_with_other_token_failure")
@@ -3667,7 +3664,7 @@ final class NCMBUserTests: NCMBTestCase {
             XCTAssertEqual(NCMBUser.currentUser!.userName, "Yamada Tarou")
             XCTAssertEqual(NCMBUser.currentUser!.sessionToken, "iXDIelJRY3ULBdms281VTmc5O")
             XCTAssertNotNil(NCMBUser.currentUser!.authData)
-            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: apple))
+            XCTAssertTrue(NSDictionary(dictionary: NCMBUser.currentUser!.authData!).isEqual(to: appleInfo))
             let error = NSError(domain: "NCMBErrorDomain", code: 404003, userInfo: [NSLocalizedDescriptionKey : "other token type"])
             XCTAssertEqual(NCMBTestUtil.getError(result: result)! as NSError, error)
             expectation?.fulfill()

--- a/NCMBTests/component/NCMBBaseTests.swift
+++ b/NCMBTests/component/NCMBBaseTests.swift
@@ -17,6 +17,9 @@
 
 import XCTest
 @testable import NCMB
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// NCMBBase のテストクラスです。
 final class NCMBBaseTests: NCMBTestCase {

--- a/NCMBTests/fieldtype/NCMBAddOperatorTests.swift
+++ b/NCMBTests/fieldtype/NCMBAddOperatorTests.swift
@@ -87,7 +87,7 @@ final class NCMBAddOperatorTests: NCMBTestCase {
 
     func test_toObject() {
         let addOperator = NCMBAddOperator(elements: ["takanokun", "takano_san"])
-        var object : [String : Any] = addOperator.toObject()
+        let object : [String : Any] = addOperator.toObject()
         XCTAssertEqual(object["__op"]! as! String, "Add")
         XCTAssertEqual((object["objects"]! as! Array<String>).count, 2)
         XCTAssertEqual((object["objects"]! as! Array<String>)[0], "takanokun")
@@ -96,7 +96,7 @@ final class NCMBAddOperatorTests: NCMBTestCase {
 
     func test_toObject_nilArray() {
         let addOperator = NCMBAddOperator(elements: [nil,"takanokun",nil])
-        var object : [String : Any] = addOperator.toObject()
+        let object : [String : Any] = addOperator.toObject()
         XCTAssertEqual(object["__op"]! as! String, "Add")
         XCTAssertEqual((object["objects"]! as! Array<Any?>).count, 3)
         XCTAssertNil((object["objects"]! as! Array<Any?>)[0])

--- a/NCMBTests/fieldtype/NCMBAddRelationOperatorTests.swift
+++ b/NCMBTests/fieldtype/NCMBAddRelationOperatorTests.swift
@@ -124,7 +124,7 @@ final class NCMBAddRelationOperatorTests: NCMBTestCase {
     
     func test_toObject() {
         let addRelationOperator = NCMBAddRelationOperator(elements: [NCMBPointer(className: "TestClass", objectId: "hogeHOGE12345678"), NCMBPointer(className: "TestClass", objectId: "hogeHOGE90123456")])
-        var object : [String : Any] = addRelationOperator.toObject()
+        let object : [String : Any] = addRelationOperator.toObject()
         XCTAssertEqual(object["__op"]! as! String, "AddRelation")
         XCTAssertEqual((object["objects"]! as! Array<Dictionary<String,Any>>).count, 2)
 

--- a/NCMBTests/fieldtype/NCMBAddUniqueOperatorTests.swift
+++ b/NCMBTests/fieldtype/NCMBAddUniqueOperatorTests.swift
@@ -87,7 +87,7 @@ final class NCMBAddUniqueOperatorTests: NCMBTestCase {
 
     func test_toObject() {
         let addUniqueOperator = NCMBAddUniqueOperator(elements: ["takanokun", "takano_san"])
-        var object : [String : Any] = addUniqueOperator.toObject()
+        let object : [String : Any] = addUniqueOperator.toObject()
         XCTAssertEqual(object["__op"]! as! String, "AddUnique")
         XCTAssertEqual((object["objects"]! as! Array<String>).count, 2)
         XCTAssertEqual((object["objects"]! as! Array<String>)[0], "takanokun")
@@ -96,7 +96,7 @@ final class NCMBAddUniqueOperatorTests: NCMBTestCase {
 
     func test_toObject_nilArray() {
         let addUniqueOperator = NCMBAddUniqueOperator(elements: [nil,"takanokun",nil])
-        var object : [String : Any] = addUniqueOperator.toObject()
+        let object : [String : Any] = addUniqueOperator.toObject()
         XCTAssertEqual(object["__op"]! as! String, "AddUnique")
         XCTAssertEqual((object["objects"]! as! Array<Any?>).count, 3)
         XCTAssertNil((object["objects"]! as! Array<Any?>)[0])

--- a/NCMBTests/fieldtype/NCMBDateFieldTests.swift
+++ b/NCMBTests/fieldtype/NCMBDateFieldTests.swift
@@ -71,7 +71,7 @@ final class NCMBDateFieldTests: NCMBTestCase {
     }
 
     func test_convertObject() {
-        var object : [String : Any] = NCMBDateField.convertObject(date: Date(timeIntervalSince1970: 507904496.789))
+        let object : [String : Any] = NCMBDateField.convertObject(date: Date(timeIntervalSince1970: 507904496.789))
         XCTAssertEqual(object["__type"]! as! String, "Date")
         XCTAssertEqual(object["iso"]! as! String, "1986-02-04T12:34:56.789Z")
     }

--- a/NCMBTests/fieldtype/NCMBFieldTypeConverterTests.swift
+++ b/NCMBTests/fieldtype/NCMBFieldTypeConverterTests.swift
@@ -140,14 +140,14 @@ final class NCMBFieldTypeConverterTests: NCMBTestCase {
 
     func test_converToObject_NCMBIncrementOperator() {
         let incrementOperator = NCMBIncrementOperator(amount: 42)
-        var object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: incrementOperator)
+        let object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: incrementOperator)
         XCTAssertEqual(object!["__op"]! as! String, "Increment")
         XCTAssertEqual(object!["amount"]! as! Int, 42)
     }
 
     func test_converToObject_NCMBAddOperator() {
         let addOperator = NCMBAddOperator(elements: ["takanokun", "takano_san"])
-        var object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: addOperator)
+        let object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: addOperator)
         XCTAssertEqual(object!["__op"]! as! String, "Add")
         XCTAssertEqual((object!["objects"]! as! Array<String>).count, 2)
         XCTAssertEqual((object!["objects"]! as! Array<String>)[0], "takanokun")
@@ -156,7 +156,7 @@ final class NCMBFieldTypeConverterTests: NCMBTestCase {
 
     func test_converToObject_NCMBAddUniqueOperator() {
         let addUniqueOperator = NCMBAddUniqueOperator(elements: ["takanokun", "takano_san"])
-        var object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: addUniqueOperator)
+        let object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: addUniqueOperator)
         XCTAssertEqual(object!["__op"]! as! String, "AddUnique")
         XCTAssertEqual((object!["objects"]! as! Array<String>).count, 2)
         XCTAssertEqual((object!["objects"]! as! Array<String>)[0], "takanokun")
@@ -165,7 +165,7 @@ final class NCMBFieldTypeConverterTests: NCMBTestCase {
 
     func test_converToObject_NCMBRemoveOperator() {
         let removeOperator = NCMBRemoveOperator(elements: ["takanokun", "takano_san"])
-        var object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: removeOperator)
+        let object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: removeOperator)
         XCTAssertEqual(object!["__op"]! as! String, "Remove")
         XCTAssertEqual((object!["objects"]! as! Array<String>).count, 2)
         XCTAssertEqual((object!["objects"]! as! Array<String>)[0], "takanokun")
@@ -177,7 +177,7 @@ final class NCMBFieldTypeConverterTests: NCMBTestCase {
         let JsontoObject2 = NCMBPointer(className: "TestClass", objectId: "hogeHOGE90123456")
         let addRelationOperator = NCMBAddRelationOperator(elements: [JsontoObject1,JsontoObject2])
 
-        var object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: addRelationOperator)
+        let object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: addRelationOperator)
         XCTAssertEqual(object!["__op"]! as! String, "AddRelation")
         XCTAssertEqual((object!["objects"]! as! Array<Dictionary<String,Any>>).count, 2)
         
@@ -197,7 +197,7 @@ final class NCMBFieldTypeConverterTests: NCMBTestCase {
         let JsontoObject2 = NCMBPointer(className: "TestClass", objectId: "hogeHOGE90123456")
         let removeRelationOperator = NCMBRemoveRelationOperator(elements: [JsontoObject1,JsontoObject2])
         
-        var object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: removeRelationOperator)
+        let object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: removeRelationOperator)
         XCTAssertEqual(object!["__op"]! as! String, "RemoveRelation")
         XCTAssertEqual((object!["objects"]! as! Array<Dictionary<String,Any>>).count, 2)
         
@@ -214,14 +214,14 @@ final class NCMBFieldTypeConverterTests: NCMBTestCase {
 
     func test_converToObject_Date() {
         let date = Date(timeIntervalSince1970: 507904496.789)
-        var object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: date)
+        let object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: date)
         XCTAssertEqual(object!["__type"]! as! String, "Date")
         XCTAssertEqual(object!["iso"]! as! String, "1986-02-04T12:34:56.789Z")
     }
 
     func test_converToObject_NCMBPointer() {
         let pointer = NCMBPointer(className: "TestClass", objectId: "abcde12345")
-        var object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: pointer)
+        let object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: pointer)
         XCTAssertEqual(object!["__type"]! as! String, "Pointer")
         XCTAssertEqual(object!["className"]! as! String, "TestClass")
         XCTAssertEqual(object!["objectId"]! as! String, "abcde12345")
@@ -229,14 +229,14 @@ final class NCMBFieldTypeConverterTests: NCMBTestCase {
 
      func test_converToObject_NCMBRelation() {
         let relation = NCMBRelation(className: "TestClass")
-        var object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: relation)
+        let object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: relation)
         XCTAssertEqual(object!["__type"]! as! String, "Relation")
         XCTAssertEqual(object!["className"]! as! String, "TestClass")
      }
 
     func test_converToObject_NCMBGeoPoint() {
         let geoPoint = NCMBGeoPoint(latitude: 35.6666269, longitude: 139.765607)
-        var object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: geoPoint)
+        let object : [String : Any]? = NCMBFieldTypeConverter.converToObject(value: geoPoint)
         XCTAssertEqual(object!["__type"]! as! String, "GeoPoint")
         XCTAssertEqual(object!["latitude"]! as! Double, Double(35.6666269))
         XCTAssertEqual(object!["longitude"]! as! Double, Double(139.765607))

--- a/NCMBTests/fieldtype/NCMBGeoPointTests.swift
+++ b/NCMBTests/fieldtype/NCMBGeoPointTests.swift
@@ -90,7 +90,7 @@ final class NCMBGeoPointTests: NCMBTestCase {
 
     func test_toObject() {
         let geoPoint = NCMBGeoPoint(latitude: 35.6666269, longitude: 139.765607)
-        var object : [String : Any] = geoPoint.toObject()
+        let object : [String : Any] = geoPoint.toObject()
         XCTAssertEqual(object["__type"]! as! String, "GeoPoint")
         XCTAssertEqual(object["latitude"]! as! Double, Double(35.6666269))
         XCTAssertEqual(object["longitude"]! as! Double, Double(139.765607))

--- a/NCMBTests/fieldtype/NCMBIncrementOperatorTests.swift
+++ b/NCMBTests/fieldtype/NCMBIncrementOperatorTests.swift
@@ -76,14 +76,14 @@ final class NCMBIncrementOperatorTests: NCMBTestCase {
 
     func test_toObject_int() {
         let incrementOperator = NCMBIncrementOperator(amount: 42)
-        var object : [String : Any] = incrementOperator.toObject()
+        let object : [String : Any] = incrementOperator.toObject()
         XCTAssertEqual(object["__op"]! as! String, "Increment")
         XCTAssertEqual(object["amount"]! as! Int, 42)
     }
 
     func test_toObject_double() {
         let incrementOperator = NCMBIncrementOperator(amount: 1.23)
-        var object : [String : Any] = incrementOperator.toObject()
+        let object : [String : Any] = incrementOperator.toObject()
         XCTAssertEqual(object["__op"]! as! String, "Increment")
         XCTAssertEqual(object["amount"]! as! Double, 1.23)
     }

--- a/NCMBTests/fieldtype/NCMBPointerTests.swift
+++ b/NCMBTests/fieldtype/NCMBPointerTests.swift
@@ -121,7 +121,7 @@ final class NCMBPointerTests: NCMBTestCase {
     
     func test_toObject() {
         let pointer = NCMBPointer(className: "TestClass", objectId: "abcde12345")
-        var object : [String : Any] = pointer.toObject()
+        let object : [String : Any] = pointer.toObject()
         XCTAssertEqual(object["__type"]! as! String, "Pointer")
         XCTAssertEqual(object["className"]! as! String, "TestClass")
         XCTAssertEqual(object["objectId"]! as! String, "abcde12345")

--- a/NCMBTests/fieldtype/NCMBRelationTests.swift
+++ b/NCMBTests/fieldtype/NCMBRelationTests.swift
@@ -67,7 +67,7 @@ final class NCMBRelationTests: NCMBTestCase {
     
     func test_toObject() {
         let relation = NCMBRelation(className: "TestClass")
-        var object : [String : Any] = relation.toObject()
+        let object : [String : Any] = relation.toObject()
         XCTAssertEqual(object["__type"]! as! String, "Relation")
         XCTAssertEqual(object["className"]! as! String, "TestClass")
     }

--- a/NCMBTests/fieldtype/NCMBRemoveOperatorTests.swift
+++ b/NCMBTests/fieldtype/NCMBRemoveOperatorTests.swift
@@ -87,7 +87,7 @@ final class NCMBRemoveOperatorTests: NCMBTestCase {
 
     func test_toObject() {
         let removeOperator = NCMBRemoveOperator(elements: ["takanokun", "takano_san"])
-        var object : [String : Any] = removeOperator.toObject()
+        let object : [String : Any] = removeOperator.toObject()
         XCTAssertEqual(object["__op"]! as! String, "Remove")
         XCTAssertEqual((object["objects"]! as! Array<String>).count, 2)
         XCTAssertEqual((object["objects"]! as! Array<String>)[0], "takanokun")
@@ -96,7 +96,7 @@ final class NCMBRemoveOperatorTests: NCMBTestCase {
 
     func test_toObject_nilArray() {
         let removeOperator = NCMBRemoveOperator(elements: [nil,"takanokun",nil])
-        var object : [String : Any] = removeOperator.toObject()
+        let object : [String : Any] = removeOperator.toObject()
         XCTAssertEqual(object["__op"]! as! String, "Remove")
         XCTAssertEqual((object["objects"]! as! Array<Any?>).count, 3)
         XCTAssertNil((object["objects"]! as! Array<Any?>)[0])

--- a/NCMBTests/fieldtype/NCMBRemoveRelationOperatorTests.swift
+++ b/NCMBTests/fieldtype/NCMBRemoveRelationOperatorTests.swift
@@ -124,7 +124,7 @@ final class NCMBRemoveRelationOperatorTests: NCMBTestCase {
     
     func test_toObject() {
         let removeRelationOperator = NCMBRemoveRelationOperator(elements: [NCMBPointer(className: "TestClass", objectId: "hogeHOGE12345678"), NCMBPointer(className: "TestClass", objectId: "hogeHOGE90123456")])
-        var object : [String : Any] = removeRelationOperator.toObject()
+        let object : [String : Any] = removeRelationOperator.toObject()
         XCTAssertEqual(object["__op"]! as! String, "RemoveRelation")
         XCTAssertEqual((object["objects"]! as! Array<Dictionary<String,Any>>).count, 2)
         

--- a/NCMBTests/helper/MockResponseBuilder.swift
+++ b/NCMBTests/helper/MockResponseBuilder.swift
@@ -16,6 +16,9 @@
 
 import Foundation
 @testable import NCMB
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// テストコードで使用するモック用のレスポンスを生成するクラスです。
 public class MockResponseBuilder {

--- a/NCMBTests/network/NCMBRequestExecutorTests.swift
+++ b/NCMBTests/network/NCMBRequestExecutorTests.swift
@@ -17,6 +17,9 @@
 import Foundation
 import XCTest
 @testable import NCMB
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// NCMBRequestExecutor のテストクラスです。
 final class NCMBRequestExecutorTests: NCMBTestCase {

--- a/NCMBTests/network/NCMBRequestTests.swift
+++ b/NCMBTests/network/NCMBRequestTests.swift
@@ -17,6 +17,9 @@
 import Foundation
 import XCTest
 @testable import NCMB
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// NCMBRequest のテストクラスです。
 final class NCMBRequestTests: NCMBTestCase {

--- a/NCMBTests/network/NCMBResponseTests.swift
+++ b/NCMBTests/network/NCMBResponseTests.swift
@@ -17,6 +17,9 @@
 
 import XCTest
 @testable import NCMB
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// NCMBResponse のテストクラスです。
 final class NCMBResponseTests: NCMBTestCase {

--- a/NCMBTests/network/NCMBSessionFactoryTests.swift
+++ b/NCMBTests/network/NCMBSessionFactoryTests.swift
@@ -17,6 +17,9 @@
 
 import XCTest
 @testable import NCMB
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// NCMBSessionFactory のテストクラスです。
 final class NCMBSessionFactoryTests: NCMBTestCase {

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.2
+
+import PackageDescription
+
+let package = Package(
+    name: "NCMB",
+    platforms: [
+        .iOS(.v10), .macOS(.v10_12)
+    ],
+    products: [
+        .library(name: "NCMB", targets: ["NCMB"]),
+    ],
+    targets: [
+        .target(
+            name: "NCMB",
+            dependencies: [],
+            path: "NCMB"
+        ),
+        .testTarget(
+            name: "NCMBTests",
+            dependencies: ["NCMB"],
+            path: "NCMBTests"
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -10,10 +10,27 @@ let package = Package(
     products: [
         .library(name: "NCMB", targets: ["NCMB"]),
     ],
+    dependencies: {
+#if canImport(CommonCrypto)
+        return []
+#else
+        return [
+            .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.3.1"),
+        ]
+#endif
+    }(),
     targets: [
         .target(
             name: "NCMB",
-            dependencies: [],
+            dependencies: {
+#if canImport(CommonCrypto)
+                return []
+#else
+                return [
+                    .product(name: "CryptoSwift", package: "CryptoSwift"),
+                ]
+#endif
+            }(),
             path: "NCMB"
         ),
         .testTarget(


### PR DESCRIPTION
## 概要(Summary)

- Linux環境におけるビルドエラーを修正します
- こちらのライブラリはLinux環境をサポート対象としていませんが、既存コード片を見た限りではLinuxをある程度意識しているということ、またREADMEに

> ※ 動作確認バージョン、開発環境につきましては今後、順次拡大する予定です。

という記載があることから鑑みて、明記されてはないもののある程度の需要があるかと思いPRとしました

- サポートポリシー的にLinux環境を今後受け入れるつもりはないなどあれば、このPRは気軽にcloseしていただいても構いません

### 変更内容

- Linux環境には完全な互換性のないObjective-C互換クラスの利用を止める
	- NSMutableDictionaryをSwiftのDictionaryに変更したのみです
	- 既存使用箇所でNSMutableDictionaryでなければならない実装箇所はなく、Objective-Cライブラリからの移植の名残なのではないかと思っています
- 各種import条件の整備、その他
	- Linux環境ではFoundation内の一部のクラスがFoundationNetworkingという別モジュールに分離しているため、そのimport
	- CommonCryptoのフォーバック実装まわり
- SwiftPMから利用するために #77 の変更を含んでいます

## 動作確認手順(Step for Confirmation)

- 既存の各種動作確認を行う
- Linux環境においてビルド・テストが通る
    - 私は次のようなDockerfileがビルドできることで確認をしました
    - （レイヤーキャッシュを強く効かせるために冗長な構造になっています）
    
```Dockerfile
FROM swift:5.3-focal as build

COPY ./Package.* ./
RUN swift package resolve

RUN mkdir NCMBTests
COPY ./NCMB ./NCMB
RUN swift build --enable-test-discovery

COPY ./NCMBTests ./NCMBTests
RUN swift test --enable-test-discovery
```
