### PR TITLE
Hotfix: Update SwiftPackage 設定

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -31,10 +31,10 @@ let package = Package(
                 ]
 #endif
             }(),
+            path: "NCMB",
             resources: [
                 .process("NCMB_Info.plist")
-            ],
-            path: "NCMB"
+            ]
         ),
         .testTarget(
             name: "NCMBTests",

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "NCMB",
     platforms: [
-        .iOS(.v15), .macOS(.v12_5)
+        .iOS(.v15), .macOS(.v12)
     ],
     products: [
         .library(name: "NCMB", targets: ["NCMB"]),

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,8 @@ let package = Package(
 #endif
             }(),
             resources: [
-                .process("NCMB_Info.plist")]
+                .process("NCMB_Info.plist")
+            ],
             path: "NCMB"
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,8 @@ let package = Package(
                 ]
 #endif
             }(),
+            resources: [
+                .process("NCMB_Info.plist")]
             path: "NCMB"
         ),
         .testTarget(


### PR DESCRIPTION
## 概要(Summary)

- Fixed #105
- iOS v15, MacOS v12 以降利用するために、swift-tools-version　バージョン 5.5に更新
- Swift tools versionを5.5に更新することで、NCMB_Info.plistファイルをResoucesに追加するために、明記する必要があったため、設定追加

## 動作確認手順(Step for Confirmation)

Run the unit test.
- Xcode 13.2.1
- 新規プロジェクトを作成し、Add packagesをクリックし、ncmb_swiftの該当ブランチ（update_package_file）を選択し、正常にインポートできたことを確認
- クイックスタートを実施し、正常にデータ登録を実施済み

## 参考

https://developer.apple.com/documentation/packagedescription/supportedplatform/macosversion
https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package
