### PR TITLE
Fix/update keywindow

### DIFF
--- a/NCMB/NCMBPush.swift
+++ b/NCMB/NCMBPush.swift
@@ -439,7 +439,7 @@ public class NCMBPush : NCMBBase {
                 richPushView.richUrl = urlStr
                 richPushView.closeCallback = completion
                 DispatchQueue.main.async {
-                    UIApplication.shared.keyWindow?.rootViewController?.present(richPushView, animated: true, completion: nil)
+                    UIApplication.shared.windows.first?.rootViewController?.present(richPushView, animated: true, completion: nil)
                 }
             }
         #endif

--- a/NCMB/richpush/NCMBRichPushView.swift
+++ b/NCMB/richpush/NCMBRichPushView.swift
@@ -47,10 +47,11 @@ class NCMBRichPushView: UIViewController, WKNavigationDelegate {
         
         var safeAreaTop:Int = 0
         var safeAreaBottom:Int = 0
+        let window = UIApplication.shared.windows.first
         
-        if #available(iOS 11.0, *) {
-            safeAreaTop = Int((UIApplication.shared.keyWindow?.safeAreaInsets.top)!)
-            safeAreaBottom = Int((UIApplication.shared.keyWindow?.safeAreaInsets.top)!)
+        if #available(iOS 13.0, *) {
+            safeAreaTop = Int(window?.safeAreaInsets.top ?? 0)
+            safeAreaBottom = Int(window?.safeAreaInsets.bottom ?? 0)
         }
         
         let rect = CGRect(x: 0,


### PR DESCRIPTION
- iOS13.0以降で以下の非推奨が出ているため非推奨を改修するためのp-rです。

```
/Users/runner/work/ncmb_swift/ncmb_swift/NCMB/richpush/NCMBRichPushView.swift:52:53: warning: 'keyWindow' was deprecated in iOS 13.0: Should not be used for applications that support multiple scenes as it returns a key window across all connected scenes
            safeAreaTop = Int((UIApplication.shared.keyWindow?.safeAreaInsets.top)!)
                                                    ^
/Users/runner/work/ncmb_swift/ncmb_swift/NCMB/richpush/NCMBRichPushView.swift:53:56: warning: 'keyWindow' was deprecated in iOS 13.0: Should not be used for applications that support multiple scenes as it returns a key window across all connected scenes
            safeAreaBottom = Int((UIApplication.shared.keyWindow?.safeAreaInsets.top)!)

```

- Xcode上でコードを改修し、ローカルでのテストが通ることを確認済み