### PR TITLE
Fix/update gray

### DIFF
--- a/NCMB/richpush/NCMBRichPushView.swift
+++ b/NCMB/richpush/NCMBRichPushView.swift
@@ -73,7 +73,7 @@ class NCMBRichPushView: UIViewController, WKNavigationDelegate {
         _activityIndicator = UIActivityIndicatorView()
         _activityIndicator.center = self.view.center
         _activityIndicator.hidesWhenStopped = true
-        _activityIndicator.style = UIActivityIndicatorView.Style.gray
+        _activityIndicator.style = UIActivityIndicatorView.Style.medium
         
         view.addSubview(_activityIndicator)
         showActivityIndicator(show: true)


### PR DESCRIPTION
- iOS13.0以降で以下の非推奨が出ているため非推奨を改修するためのp-rです。

```
/Users/runner/work/ncmb_swift/ncmb_swift/NCMB/richpush/NCMBRichPushView.swift:76:66: warning: 'gray' was deprecated in iOS 13.0: renamed to 'UIActivityIndicatorView.Style.medium'
        _activityIndicator.style = UIActivityIndicatorView.Style.gray
                                                                 ^
/Users/runner/work/ncmb_swift/ncmb_swift/NCMB/richpush/NCMBRichPushView.swift:76:66: note: use 'UIActivityIndicatorView.Style.medium' instead
        _activityIndicator.style = UIActivityIndicatorView.Style.gray
                                                                 ^~~~
                                                                 UIActivityIndicatorView.Style.medium
```

- Xcode上でコードを改修し、ローカルでのテストが通ることを確認済み