### PR TITLE
ファイルを検索時にfileNameが空の文字列になっている不具合を修正

### DIFF
--- a/NCMB/NCMBFile.swift
+++ b/NCMB/NCMBFile.swift
@@ -64,10 +64,11 @@ public class NCMBFile : NCMBBase {
     /// - Parameter fields: フィールド内容
     /// - Parameter modifiedFieldKeys: 更新フィールド名一覧
     required init(className: String, fields: [String : Any], modifiedFieldKeys: Set<String> = []) {
-        if (fields.keys.contains(NCMBFile.FIELDNAME_FILENAME) && fields[NCMBFile.FIELDNAME_FILENAME] is String) {
-            self._fileName = fields[NCMBFile.FIELDNAME_FILENAME] as! String
-        } else {
-            self._fileName = ""
+        self._fileName = ""
+        if let value = fields[NCMBFile.FIELDNAME_FILENAME] as Any? {
+            if let filename = value as? String {
+                self._fileName = filename
+            }
         }
         super.init(className: className, fields: fields, modifiedFieldKeys: modifiedFieldKeys)
     }

--- a/NCMB/NCMBFile.swift
+++ b/NCMB/NCMBFile.swift
@@ -64,7 +64,11 @@ public class NCMBFile : NCMBBase {
     /// - Parameter fields: フィールド内容
     /// - Parameter modifiedFieldKeys: 更新フィールド名一覧
     required init(className: String, fields: [String : Any], modifiedFieldKeys: Set<String> = []) {
-        self._fileName = ""
+        if (fields.keys.contains(NCMBFile.FIELDNAME_FILENAME)) {
+            self._fileName = fields[NCMBFile.FIELDNAME_FILENAME] as! String
+        } else {
+            self._fileName = ""
+        }
         super.init(className: className, fields: fields, modifiedFieldKeys: modifiedFieldKeys)
     }
 

--- a/NCMB/NCMBFile.swift
+++ b/NCMB/NCMBFile.swift
@@ -64,7 +64,7 @@ public class NCMBFile : NCMBBase {
     /// - Parameter fields: フィールド内容
     /// - Parameter modifiedFieldKeys: 更新フィールド名一覧
     required init(className: String, fields: [String : Any], modifiedFieldKeys: Set<String> = []) {
-        if (fields.keys.contains(NCMBFile.FIELDNAME_FILENAME)) {
+        if (fields.keys.contains(NCMBFile.FIELDNAME_FILENAME) && fields[NCMBFile.FIELDNAME_FILENAME] is String) {
             self._fileName = fields[NCMBFile.FIELDNAME_FILENAME] as! String
         } else {
             self._fileName = ""

--- a/NCMBTests/NCMBQueryTests.swift
+++ b/NCMBTests/NCMBQueryTests.swift
@@ -282,16 +282,18 @@ final class NCMBQueryTests: NCMBTestCase {
     }
     
     func test_getResultObjects_file() {
-        let objectA : [String : Any] = ["objectId":"abcdefg12345", "fileName":"filename_a", "fileSize":1234, "mimeType":"text/plain"]
-        let objectB : [String : Any] = ["objectId":"67890hijklmn", "fileName":"filename_b", "fileSize":1222, "mimeType":"image/jpg"]
-        let objectC : [String : Any] = ["objectId":"opqr76543stu", "fileName":"filename_c", "fileSize":778977, "mimeType":"image/jpg"]
+        let objectA : [String : Any] = ["fileName":"filename_a", "fileSize":1234, "mimeType":"text/plain"]
+        let objectB : [String : Any] = ["fileName":"filename_b", "fileSize":1222, "mimeType":"image/jpg"]
+        let objectC : [String : Any] = [ "fileName":"filename_c", "fileSize":778977, "mimeType":"image/jpg"]
         let contents : [String : Any] = ["count":3, "results":[objectA, objectB, objectC]]
         let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode: 201)
 
         let sut = NCMBFile.query
         let results : [NCMBFile] = sut.getResultObjects(response: response)
         XCTAssertEqual(results.count, 3)
-        XCTAssertEqual(results[2].fileName, "filename_c")
+        XCTAssertEqual(results[0].fileName , "filename_a")
+        XCTAssertEqual(results[1].fileName , "filename_b")
+        XCTAssertEqual(results[2].fileName , "filename_c")
     }
 
     func test_getResultObjects_invalidMember() {

--- a/NCMBTests/NCMBQueryTests.swift
+++ b/NCMBTests/NCMBQueryTests.swift
@@ -280,6 +280,19 @@ final class NCMBQueryTests: NCMBTestCase {
         XCTAssertEqual(results.count, 3)
         XCTAssertEqual(results[2]["objectId"], "opqr76543stu")
     }
+    
+    func test_getResultObjects_file() {
+        let objectA : [String : Any] = ["objectId":"abcdefg12345", "fileName":"filename_a", "fileSize":1234, "mimeType":"text/plain"]
+        let objectB : [String : Any] = ["objectId":"67890hijklmn", "fileName":"filename_b", "fileSize":1222, "mimeType":"image/jpg"]
+        let objectC : [String : Any] = ["objectId":"opqr76543stu", "fileName":"filename_c", "fileSize":778977, "mimeType":"image/jpg"]
+        let contents : [String : Any] = ["count":3, "results":[objectA, objectB, objectC]]
+        let response : NCMBResponse = MockResponseBuilder.createResponse(contents: contents, statusCode: 201)
+
+        let sut = NCMBFile.query
+        let results : [NCMBFile] = sut.getResultObjects(response: response)
+        XCTAssertEqual(results.count, 3)
+        XCTAssertEqual(results[2].fileName, "filename_c")
+    }
 
     func test_getResultObjects_invalidMember() {
         let objectA : [String : Any] = ["objectId":"abcdefg12345", "field_a":"value_a", "field_b":"value_b", "field_c":"value_c"]


### PR DESCRIPTION
## 概要(Summary)

- ファイルを検索する場合、fileNameを取得すると空の文字列が戻ってきた不具合を修正
- ファイル検索するテストケースを追加
- Fixed #132 

## 動作確認手順(Step for Confirmation)

Run the unit test.
